### PR TITLE
feat: add jiraKey alias support to field mappings

### DIFF
--- a/src/commands/createIssue.ts
+++ b/src/commands/createIssue.ts
@@ -7,6 +7,7 @@ import {checkCommandCallback} from "../tools/checkCommandCallback";
 import {useTranslations} from "../localization/translator";
 import {readJiraFieldsFromFile} from "../file_operations/commonPrepareData";
 import {JiraIssueType, JiraProject} from "../interfaces";
+import {obsidianJiraFieldMappings} from "../default/obsidianJiraFieldsMapping";
 import {IssueAddSummaryModal} from "../modals/IssueAddSummaryModal";
 
 const t = useTranslations("commands.create_issue").t;
@@ -72,11 +73,16 @@ async function checkIssueTypes(plugin: JiraPlugin, fields: any): Promise<void> {
 }
 
 async function checkSummary(plugin: JiraPlugin, fields: any): Promise<void> {
-	if (!fields.summary) {
+	const mergedMappings = {...obsidianJiraFieldMappings, ...plugin.settings.fieldMapping.fieldMappings};
+	const summarySourceField = Object.entries(mergedMappings).find(
+		([key, mapping]) => (mapping.jiraKey || key) === "summary" && mapping.toJira(fields[key]) !== null
+	)?.[0] ?? "summary";
+
+	if (!fields[summarySourceField]) {
 		await new Promise<void>((resolve) => {
 			new IssueAddSummaryModal(plugin.app,
 				async (summary: string) => {
-					fields.summary = summary;
+					fields[summarySourceField] = summary;
 					resolve();
 				}).open();
 		});

--- a/src/default/obsidianJiraFieldsMapping.ts
+++ b/src/default/obsidianJiraFieldsMapping.ts
@@ -3,6 +3,7 @@ import {JiraIssue} from "../interfaces";
 export interface FieldMapping {
 	toJira: (value: any) => any;
 	fromJira: (issue: JiraIssue, data_source: Record<string, any> | null) => any;
+	jiraKey?: string;
 }
 
 export const obsidianJiraFieldMappings: Record<string, FieldMapping> = {

--- a/src/interfaces/settingsTypes.ts
+++ b/src/interfaces/settingsTypes.ts
@@ -12,6 +12,7 @@ export type JiraFieldMappingFunction = (...args: any[]) => any;
 export interface JiraFieldMapping {
 	toJira: JiraFieldMappingFunction;
 	fromJira: JiraFieldMappingFunction;
+	jiraKey?: string;
 }
 
 /**
@@ -20,6 +21,7 @@ export interface JiraFieldMapping {
 export interface JiraFieldMappingString {
 	toJira: string;
 	fromJira: string;
+	jiraKey?: string;
 }
 
 /**

--- a/src/settings/tools/mappingTransformers.ts
+++ b/src/settings/tools/mappingTransformers.ts
@@ -18,7 +18,8 @@ export function convertFunctionMappingsToStrings(
 		if (mapping && typeof mapping === 'object' && 'toJira' in mapping && 'fromJira' in mapping) {
 			result[fieldName] = {
 				toJira: jiraFunctionToString(mapping.toJira, false),
-				fromJira: jiraFunctionToString(mapping.fromJira, true)
+				fromJira: jiraFunctionToString(mapping.fromJira, true),
+				...(mapping.jiraKey ? { jiraKey: mapping.jiraKey } : {}),
 			};
 		}
 	}
@@ -51,9 +52,12 @@ export async function collectFieldMappingsFromUI(
 
 		// Only save valid mappings with field name filled
 		if (fieldName) {
+			const jiraKeyInput = item.querySelector(".jira-key-input");
+			const jiraKey = jiraKeyInput ? (jiraKeyInput as HTMLInputElement).value.trim() : undefined;
 			mappings[fieldName] = {
 				toJira: toJira,
-				fromJira: fromJira
+				fromJira: fromJira,
+				...(jiraKey ? { jiraKey } : {}),
 			};
 		}
 	});

--- a/src/tools/convertFunctionString.ts
+++ b/src/tools/convertFunctionString.ts
@@ -300,10 +300,10 @@ export function functionToExpressionString(fn: Function): string {
 }
 
 export async function transform_string_to_functions_mappings  (
-	mappings: Record<string, { toJira: string; fromJira: string }>, extraValidate: boolean = true)  {
+	mappings: Record<string, { toJira: string; fromJira: string; jiraKey?: string }>, extraValidate: boolean = true)  {
 	// Also convert to functions for runtime use
 	const transformedMappings: Record<string, FieldMapping> = {};
-	for (const [fieldName, { toJira, fromJira }] of Object.entries(mappings)) {
+	for (const [fieldName, { toJira, fromJira, jiraKey }] of Object.entries(mappings)) {
 		const toJiraFn = safeStringToFunction(toJira, 'toJira', extraValidate);
 		const fromJiraFn = safeStringToFunction(fromJira, 'fromJira', extraValidate);
 
@@ -311,6 +311,7 @@ export async function transform_string_to_functions_mappings  (
 			transformedMappings[fieldName] = {
 				toJira: await toJiraFn as (value: any) => any,
 				fromJira: await fromJiraFn as (issue: JiraIssue, data_source: Record<string, any>) => any,
+				...(jiraKey ? { jiraKey } : {}),
 			};
 		} else {
 			console.warn(`Invalid function in field: ${fieldName}`);

--- a/src/tools/mapObsidianJiraFields.ts
+++ b/src/tools/mapObsidianJiraFields.ts
@@ -27,7 +27,8 @@ export function localToJiraFields(
 				// Skip fields that shouldn't be sent to Jira
 				if (mapping.toJira(value) === null) continue;
 
-				jiraFields[key] = mapping.toJira(value);
+				const jiraKey = mapping.jiraKey || key;
+				jiraFields[jiraKey] = mapping.toJira(value);
 			} catch (e) {
 				console.error(`Error mapping for ${key}: ${e}`);
 				new Notice(`Error mapping for ${key}: ${e}`);


### PR DESCRIPTION
## Problem

Some Obsidian plugins (e.g. TaskNotes) use `title` as the primary note title property instead of `summary`. Without aliasing, users had to either rename their property or maintain a duplicate `summary` field. The field mapping system had no way to map a local property name to a different Jira field name.

## Changes

- **`src/default/obsidianJiraFieldsMapping.ts`** — Added optional `jiraKey?: string` to the `FieldMapping` interface.
- **`src/interfaces/settingsTypes.ts`** — Added `jiraKey?: string` to both `JiraFieldMapping` and `JiraFieldMappingString`.
- **`src/tools/mapObsidianJiraFields.ts`** — `localToJiraFields()` now uses `mapping.jiraKey || key` when building the Jira payload, so a local field named `title` can be submitted as `summary`.
- **`src/settings/tools/mappingTransformers.ts`** — `jiraKey` is preserved when transforming string mappings to compiled functions.
- **`src/commands/createIssue.ts`** — `checkSummary()` now finds whichever local field resolves to the `summary` Jira key (via `jiraKey`) rather than always looking for a field literally named `summary`.

## Usage

```json
"title": {
  "toJira": "value",
  "fromJira": "issue.fields.summary",
  "jiraKey": "summary"
}
```

This allows a note property named `title` to be synced to/from the Jira `summary` field transparently.