### PR TITLE
fix: update issue status no longer clears description and comments

### DIFF
--- a/src/file_operations/createUpdateIssue.ts
+++ b/src/file_operations/createUpdateIssue.ts
@@ -5,6 +5,7 @@ import {prepareJiraFieldsFromFile} from "./commonPrepareData";
 import {localToJiraFields, updateJiraToLocal} from "../tools/mapObsidianJiraFields";
 import {JiraIssue, JiraTransitionType} from "../interfaces";
 import {obsidianJiraFieldMappings} from "../default/obsidianJiraFieldsMapping";
+import {updateJiraSyncContent} from "../tools/sectionTools";
 
 export async function updateIssueFromFile(plugin: JiraPlugin, file: TFile): Promise<string> {
 	let fields = await prepareJiraFieldsFromFile(plugin, file);
@@ -48,6 +49,25 @@ export async function updateStatusFromFile(plugin: JiraPlugin, file: TFile, tran
 	}
 
 	await updateJiraStatus(plugin, fields.key, transition.id);
-	await updateJiraToLocal(plugin, file, {fields: {status: {name: transition.status}}} as JiraIssue);
+
+	// Only update the status field. Calling updateJiraToLocal with a partial issue
+	// causes all fromJira mappings to run with undefined inputs, producing empty strings
+	// that overwrite description and comments.
+	const allMappings = {...obsidianJiraFieldMappings, ...plugin.settings.fieldMapping.fieldMappings};
+	const statusMapping = allMappings['status'];
+	const minimalIssue = {fields: {status: {name: transition.status}}} as JiraIssue;
+	const localStatusValue = statusMapping
+		? statusMapping.fromJira(minimalIssue, {})
+		: transition.status;
+
+	if (localStatusValue !== null && localStatusValue !== undefined) {
+		await plugin.app.fileManager.processFrontMatter(file, (frontmatter) => {
+			frontmatter['status'] = localStatusValue;
+		});
+		await plugin.app.vault.process(file, (fileContent) => {
+			return updateJiraSyncContent(fileContent, {status: String(localStatusValue)});
+		});
+	}
+
 	return fields.key;
 }


### PR DESCRIPTION
## Problem

Using the **Update issue status in Jira** command wiped the description and any pulled comments from the note. After the status transition, those sections would be blank.

## Root cause

`updateStatusFromFile()` called `updateJiraToLocal()` with a fake minimal issue object — `{fields: {status: {name: transition.status}}}` — to reflect the new status in the note. `updateJiraToLocal` runs all `fromJira` mappings against this fake object. Every field other than `status` received `undefined` as input. For example, `adfToMarkdown(undefined)` returns `''`, and because `''` passes the `!== null && !== undefined` guard, it overwrote the existing description and comment content with empty strings.

## Fix

- **`src/file_operations/createUpdateIssue.ts`** — Replaced the `updateJiraToLocal` call with a targeted status-only update: evaluates the `status` field mapping against a minimal issue (which is safe — status is the only field present), then writes the result directly to frontmatter via `processFrontMatter` and to any sync content markers via `updateJiraSyncContent`. No other fields are touched.