### PR TITLE
feat: pull full issue from Jira after creation

### DIFF
--- a/src/file_operations/createUpdateIssue.ts
+++ b/src/file_operations/createUpdateIssue.ts
@@ -1,6 +1,6 @@
 import JiraPlugin from "../main";
 import {TFile} from "obsidian";
-import {createJiraIssue, updateJiraIssue, updateJiraStatus} from "../api";
+import {createJiraIssue, fetchIssue, updateJiraIssue, updateJiraStatus} from "../api";
 import {prepareJiraFieldsFromFile} from "./commonPrepareData";
 import {localToJiraFields, updateJiraToLocal} from "../tools/mapObsidianJiraFields";
 import {JiraIssue, JiraTransitionType} from "../interfaces";
@@ -32,10 +32,14 @@ export async function createIssueFromFile(
 	const issueData = await createJiraIssue(plugin, fields);
 	const issueKey = issueData.key;
 
-	// Update frontmatter with the new issue key
+	// Write key immediately so it's never lost
 	await plugin.app.fileManager.processFrontMatter(file, (frontmatter) => {
 		frontmatter["key"] = issueKey;
 	});
+
+	// Pull the created issue back from Jira to populate all remaining synced fields
+	const createdIssue = await fetchIssue(plugin, issueKey);
+	await updateJiraToLocal(plugin, file, createdIssue);
 
 	return issueKey;
 }


### PR DESCRIPTION
## Problem

After creating an issue in Jira, the plugin only wrote the new issue key back to the note's frontmatter. All other fields populated by Jira on creation (status, assignee, reporter, created/updated timestamps, link, etc.) required a separate manual pull to appear in the note.

## Changes

- **`src/file_operations/createUpdateIssue.ts`** — After creating the issue, immediately writes the key to frontmatter (so it is never lost even if the subsequent fetch fails), then calls `fetchIssue` + `updateJiraToLocal` to pull the full created issue back and populate all synced fields in one step.