### PR TITLE
feat: add comment to Jira from editor

### DIFF
--- a/src/api/issues.ts
+++ b/src/api/issues.ts
@@ -3,6 +3,7 @@ import {JiraIssue, JiraTransitionType} from "../interfaces";
 import {baseRequest, sanitizeObject} from "./base";
 import {Notice} from "obsidian";
 import {chunkArray, createLimiter} from "../tools/asyncLimiter";
+import {markdownToAdf} from "../tools/markdownToAdf";
 
 
 /**
@@ -253,6 +254,27 @@ export async function addWorkLog(
 		new Notice(`Work log added successfully to ${issueKey}`);
 	}
 
+	return response;
+}
+
+
+/**
+ * Add a comment to a Jira issue
+ */
+export async function addComment(
+	plugin: JiraPlugin,
+	issueKey: string,
+	markdownText: string
+): Promise<any> {
+	let body: any;
+	if (plugin.settings.connection.apiVersion === "3") {
+		body = markdownToAdf(markdownText);
+	} else {
+		body = markdownText;
+	}
+	const payload = JSON.stringify({ body });
+	const response = await baseRequest(plugin, 'post', `/issue/${issueKey}/comment`, payload);
+	new Notice(`Comment added to ${issueKey}`);
 	return response;
 }
 

--- a/src/commands/addComment.ts
+++ b/src/commands/addComment.ts
@@ -1,0 +1,36 @@
+import {Editor, MarkdownView, Notice} from "obsidian";
+import JiraPlugin from "../main";
+import {IssueCommentModal} from "../modals";
+import {addComment, validateSettings} from "../api";
+import {useTranslations} from "../localization/translator";
+
+const t = useTranslations("commands.add_comment").t;
+
+export function registerAddCommentCommand(plugin: JiraPlugin): void {
+	plugin.addCommand({
+		id: "add-comment-jira",
+		name: t("name"),
+		editorCheckCallback: (checking: boolean, editor: Editor, view: MarkdownView) => {
+			if (!validateSettings(plugin)) return false;
+			if (!view.file) return false;
+
+			const frontmatter = plugin.app.metadataCache.getFileCache(view.file)?.frontmatter;
+			const issueKey = frontmatter?.key;
+			if (!issueKey) return false;
+
+			if (!checking) {
+				const selectedText = editor.getSelection();
+				new IssueCommentModal(plugin.app, selectedText, async (commentText: string) => {
+					try {
+						await addComment(plugin, issueKey, commentText);
+					} catch (error) {
+						new Notice(t("error") + ": " + (error.message || "Unknown error"));
+						console.error(error);
+					}
+				}).open();
+			}
+
+			return true;
+		},
+	});
+}

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -1,3 +1,4 @@
+export * from './addComment';
 export * from './addWorkLogBatch';
 export * from './addWorkLogManually';
 export * from './batchFetchIssues';

--- a/src/default/obsidianJiraFieldsMapping.ts
+++ b/src/default/obsidianJiraFieldsMapping.ts
@@ -87,8 +87,9 @@ export const obsidianJiraFieldMappings: Record<string, FieldMapping> = {
 				const author = c.author?.displayName ?? 'Unknown';
 				const date = c.created ? c.created.replace('T', ' ').substring(0, 19) : '';
 				const body = adfToMarkdown(c.body) ?? '';
-				return `### ${author} — ${date}\n\n${body}`;
-			}).join('\n\n---\n\n');
+				const calloutBody = body.split('\n').map((l: string) => l === '' ? '>' : `> ${l}`).join('\n');
+				return `> [!note]+ ${author} — ${date}\n> \n${calloutBody}`;
+			}).join('\n\n');
 		},
 	},
 };

--- a/src/default/obsidianJiraFieldsMapping.ts
+++ b/src/default/obsidianJiraFieldsMapping.ts
@@ -1,4 +1,5 @@
 import {JiraIssue} from "../interfaces";
+import {jiraToMarkdown} from "../tools/markdownHtml";
 
 export interface FieldMapping {
 	toJira: (value: any) => any;
@@ -12,7 +13,7 @@ export const obsidianJiraFieldMappings: Record<string, FieldMapping> = {
 	},
 	"description": {
 		toJira: () => null,
-		fromJira: (issue) => issue.fields.description,
+		fromJira: (issue) => jiraToMarkdown(issue.fields.description),
 	},
 	"key": {
 		toJira: () => null,

--- a/src/default/obsidianJiraFieldsMapping.ts
+++ b/src/default/obsidianJiraFieldsMapping.ts
@@ -1,5 +1,6 @@
 import {JiraIssue} from "../interfaces";
 import {jiraToMarkdown} from "../tools/markdownHtml";
+import {adfToMarkdown} from "../tools/markdownToAdf";
 
 export interface FieldMapping {
 	toJira: (value: any) => any;
@@ -76,5 +77,18 @@ export const obsidianJiraFieldMappings: Record<string, FieldMapping> = {
 	"progress": {
 		toJira: () => null,
 		fromJira: (issue) => issue.fields.aggregateprogress.percent+'%',
+	},
+	"comment": {
+		toJira: () => null,
+		fromJira: (issue) => {
+			const comments = issue.fields.comment?.comments;
+			if (!comments?.length) return '';
+			return comments.map((c: any) => {
+				const author = c.author?.displayName ?? 'Unknown';
+				const date = c.created ? c.created.replace('T', ' ').substring(0, 19) : '';
+				const body = adfToMarkdown(c.body) ?? '';
+				return `### ${author} — ${date}\n\n${body}`;
+			}).join('\n\n---\n\n');
+		},
 	},
 };

--- a/src/localization/source/en/commands/add_comment.yaml
+++ b/src/localization/source/en/commands/add_comment.yaml
@@ -1,0 +1,2 @@
+name: Add comment to Jira
+error: Error adding comment

--- a/src/localization/source/en/modals/comment.yaml
+++ b/src/localization/source/en/modals/comment.yaml
@@ -1,0 +1,11 @@
+name: Add Jira comment
+
+body:
+    name: Comment
+    desc: "Write your comment here, or select text in the editor before running this command to pre-fill it"
+    placeholder: "Write your comment here. Tip: select text in the editor before running this command to pre-fill."
+
+submit: Submit
+
+warns:
+    empty: Comment cannot be empty

--- a/src/localization/source/ru/commands/add_comment.yaml
+++ b/src/localization/source/ru/commands/add_comment.yaml
@@ -1,0 +1,2 @@
+name: Add comment to Jira
+error: Error adding comment

--- a/src/localization/source/ru/modals/comment.yaml
+++ b/src/localization/source/ru/modals/comment.yaml
@@ -1,0 +1,11 @@
+name: Add Jira comment
+
+body:
+    name: Comment
+    desc: "Write your comment here, or select text in the editor before running this command to pre-fill it"
+    placeholder: "Write your comment here. Tip: select text in the editor before running this command to pre-fill."
+
+submit: Submit
+
+warns:
+    empty: Comment cannot be empty

--- a/src/main.ts
+++ b/src/main.ts
@@ -5,7 +5,7 @@ import {
 	registerUpdateIssueCommand, registerUpdateWorkLogManuallyCommand,
 	registerGetCurrentIssueCommand, registerUpdateWorkLogBatchCommand,
 	registerCreateIssueCommand, registerGetIssueCommandWithCustomKey, registerUpdateIssueStatusCommand,
-	registerBatchFetchIssuesCommand
+	registerBatchFetchIssuesCommand, registerAddCommentCommand
 } from "./commands";
 import {transform_string_to_functions_mappings} from "./tools/convertFunctionString";
 import {createJiraSyncExtension} from "./postprocessing/livePreview";
@@ -36,6 +36,7 @@ export default class JiraPlugin extends Plugin {
 
 		registerUpdateWorkLogManuallyCommand(this);
 		registerUpdateWorkLogBatchCommand(this);
+		registerAddCommentCommand(this);
 
 		// Add settings tab
 		this.addSettingTab(new JiraSettingTab(this.app, this));

--- a/src/modals/IssueCommentModal.ts
+++ b/src/modals/IssueCommentModal.ts
@@ -1,4 +1,4 @@
-import {App, Modal, Notice, Setting} from "obsidian";
+import {App, Modal, Notice, Setting, TextAreaComponent} from "obsidian";
 import {useTranslations} from "../localization/translator";
 
 const t = useTranslations("modals.comment").t;
@@ -20,31 +20,37 @@ export class IssueCommentModal extends Modal {
 	onOpen() {
 		new Setting(this.contentEl).setName(t("name")).setHeading();
 
-		new Setting(this.contentEl)
-			.setName(t("body.name"))
-			.addTextArea((text) => {
-				text
-					.setValue(this.commentText)
-					.onChange((value) => {
-						this.commentText = value;
-					});
-				text.inputEl.rows = 10;
-				text.inputEl.style.width = "100%";
+		const textarea = new TextAreaComponent(this.contentEl)
+			.setPlaceholder(t("body.placeholder"))
+			.setValue(this.commentText)
+			.onChange((value) => {
+				this.commentText = value;
 			});
+		textarea.inputEl.rows = 10;
+		textarea.inputEl.style.width = "100%";
+		textarea.inputEl.style.marginBottom = "0.75em";
+		textarea.inputEl.addEventListener("keydown", (e) => {
+			if (e.ctrlKey && e.key === "Enter") {
+				e.preventDefault();
+				this.submit();
+			}
+		});
 
 		new Setting(this.contentEl)
 			.addButton((btn) =>
 				btn
 					.setButtonText(t("submit"))
 					.setCta()
-					.onClick(() => {
-						if (!this.commentText.trim()) {
-							new Notice(t("warns.empty"));
-							return;
-						}
-						this.close();
-						this.onSubmit(this.commentText);
-					})
+					.onClick(() => this.submit())
 			);
+	}
+
+	private submit() {
+		if (!this.commentText.trim()) {
+			new Notice(t("warns.empty"));
+			return;
+		}
+		this.close();
+		this.onSubmit(this.commentText);
 	}
 }

--- a/src/modals/IssueCommentModal.ts
+++ b/src/modals/IssueCommentModal.ts
@@ -1,0 +1,50 @@
+import {App, Modal, Notice, Setting} from "obsidian";
+import {useTranslations} from "../localization/translator";
+
+const t = useTranslations("modals.comment").t;
+
+/**
+ * Modal for adding a comment to a Jira issue.
+ * Pre-populated with any text that was selected in the editor when the command was invoked.
+ */
+export class IssueCommentModal extends Modal {
+	private onSubmit: (commentText: string) => void;
+	private commentText: string;
+
+	constructor(app: App, initialText: string, onSubmit: (commentText: string) => void) {
+		super(app);
+		this.commentText = initialText;
+		this.onSubmit = onSubmit;
+	}
+
+	onOpen() {
+		new Setting(this.contentEl).setName(t("name")).setHeading();
+
+		new Setting(this.contentEl)
+			.setName(t("body.name"))
+			.addTextArea((text) => {
+				text
+					.setValue(this.commentText)
+					.onChange((value) => {
+						this.commentText = value;
+					});
+				text.inputEl.rows = 10;
+				text.inputEl.style.width = "100%";
+			});
+
+		new Setting(this.contentEl)
+			.addButton((btn) =>
+				btn
+					.setButtonText(t("submit"))
+					.setCta()
+					.onClick(() => {
+						if (!this.commentText.trim()) {
+							new Notice(t("warns.empty"));
+							return;
+						}
+						this.close();
+						this.onSubmit(this.commentText);
+					})
+			);
+	}
+}

--- a/src/modals/index.ts
+++ b/src/modals/index.ts
@@ -1,3 +1,4 @@
+export * from "./IssueCommentModal";
 export * from "./IssueSearchModal";
 export * from "./IssueStatusModal";
 export * from "./IssueTypeModal";

--- a/src/tools/convertFunctionString.ts
+++ b/src/tools/convertFunctionString.ts
@@ -5,6 +5,7 @@ import {debugLog} from "./debugLogging";
 import {FieldMapping} from "../default/obsidianJiraFieldsMapping";
 import {defaultIssue} from "../default/defaultIssue";
 import {jiraToMarkdown, markdownToJira} from "./markdownHtml";
+import {markdownToAdf} from "./markdownToAdf";
 
 // Constants for validation and error messages
 const FORBIDDEN_PATTERNS = ["document", "window", "eval", "Function", "fetch", "setTimeout", "globalThis"];
@@ -12,6 +13,7 @@ const SYNTAX_KEYWORDS = ["return", "if", "else", "for", "while", "switch", "try"
 const SAFE_GLOBALS = {
 	jiraToMarkdown,
 	markdownToJira,
+	markdownToAdf,
 	JSON: {
 		parse: JSON.parse,
 		stringify: JSON.stringify
@@ -175,6 +177,7 @@ export async function safeStringToFunction(
 		const context = {
 			jiraToMarkdown,
 			markdownToJira,
+			markdownToAdf,
 			JSON,
 			Math,
 			Date,

--- a/src/tools/convertFunctionString.ts
+++ b/src/tools/convertFunctionString.ts
@@ -5,7 +5,7 @@ import {debugLog} from "./debugLogging";
 import {FieldMapping} from "../default/obsidianJiraFieldsMapping";
 import {defaultIssue} from "../default/defaultIssue";
 import {jiraToMarkdown, markdownToJira} from "./markdownHtml";
-import {markdownToAdf} from "./markdownToAdf";
+import {markdownToAdf, adfToMarkdown} from "./markdownToAdf";
 
 // Constants for validation and error messages
 const FORBIDDEN_PATTERNS = ["document", "window", "eval", "Function", "fetch", "setTimeout", "globalThis"];
@@ -14,6 +14,7 @@ const SAFE_GLOBALS = {
 	jiraToMarkdown,
 	markdownToJira,
 	markdownToAdf,
+	adfToMarkdown,
 	JSON: {
 		parse: JSON.parse,
 		stringify: JSON.stringify
@@ -178,6 +179,7 @@ export async function safeStringToFunction(
 			jiraToMarkdown,
 			markdownToJira,
 			markdownToAdf,
+			adfToMarkdown,
 			JSON,
 			Math,
 			Date,

--- a/src/tools/mapObsidianJiraFields.ts
+++ b/src/tools/mapObsidianJiraFields.ts
@@ -1,5 +1,4 @@
 import {JiraIssue} from "../interfaces";
-import {jiraToMarkdown} from "./markdownHtml";
 import {Notice, TFile} from "obsidian";
 import JiraPlugin from "../main";
 import {extractAllJiraSyncValuesFromContent, updateJiraSyncContent} from "./sectionTools";
@@ -66,7 +65,7 @@ export async function updateJiraToLocal(
 		let updatedContent = fileContent;
 		let updatesDict: Record<string, string> = {};
 		for (const [fieldName, fieldValue] of Object.entries(syncSections)) {
-			updatesDict[fieldName] = jiraToMarkdown(fieldValue);
+			updatesDict[fieldName] = fieldValue;
 		}
 
 		debugLog(`Updating sync sections: ${JSON.stringify(updatesDict)}`);

--- a/src/tools/markdownToAdf.ts
+++ b/src/tools/markdownToAdf.ts
@@ -1,0 +1,199 @@
+interface AdfTextMark {
+	type: 'strong' | 'em' | 'code';
+}
+
+interface AdfTextNode {
+	type: 'text';
+	text: string;
+	marks?: AdfTextMark[];
+}
+
+interface AdfInlineNode {
+	type: 'hardBreak';
+}
+
+type AdfInlineContent = AdfTextNode | AdfInlineNode;
+
+interface AdfParagraphNode {
+	type: 'paragraph';
+	content: AdfInlineContent[];
+}
+
+interface AdfHeadingNode {
+	type: 'heading';
+	attrs: { level: number };
+	content: AdfInlineContent[];
+}
+
+interface AdfCodeBlockNode {
+	type: 'codeBlock';
+	attrs: { language: string };
+	content: [{ type: 'text'; text: string }];
+}
+
+interface AdfListItemNode {
+	type: 'listItem';
+	content: [AdfParagraphNode];
+}
+
+interface AdfBulletListNode {
+	type: 'bulletList';
+	content: AdfListItemNode[];
+}
+
+interface AdfOrderedListNode {
+	type: 'orderedList';
+	content: AdfListItemNode[];
+}
+
+interface AdfRuleNode {
+	type: 'rule';
+}
+
+type AdfBlockNode =
+	| AdfParagraphNode
+	| AdfHeadingNode
+	| AdfCodeBlockNode
+	| AdfBulletListNode
+	| AdfOrderedListNode
+	| AdfRuleNode;
+
+interface AdfDoc {
+	version: 1;
+	type: 'doc';
+	content: AdfBlockNode[];
+}
+
+function parseInline(text: string): AdfInlineContent[] {
+	const nodes: AdfInlineContent[] = [];
+	const regex = /(\*\*(.+?)\*\*|\*(.+?)\*|`([^`]+)`)/g;
+	let lastIndex = 0;
+	let match: RegExpExecArray | null;
+
+	while ((match = regex.exec(text)) !== null) {
+		if (match.index > lastIndex) {
+			nodes.push({ type: 'text', text: text.slice(lastIndex, match.index) });
+		}
+		if (match[2] !== undefined) {
+			nodes.push({ type: 'text', text: match[2], marks: [{ type: 'strong' }] });
+		} else if (match[3] !== undefined) {
+			nodes.push({ type: 'text', text: match[3], marks: [{ type: 'em' }] });
+		} else if (match[4] !== undefined) {
+			nodes.push({ type: 'text', text: match[4], marks: [{ type: 'code' }] });
+		}
+		lastIndex = match.index + match[0].length;
+	}
+
+	if (lastIndex < text.length) {
+		nodes.push({ type: 'text', text: text.slice(lastIndex) });
+	}
+
+	return nodes.length > 0 ? nodes : [{ type: 'text', text }];
+}
+
+export function markdownToAdf(markdown: string): AdfDoc | null {
+	if (!markdown || !markdown.trim()) return null;
+
+	const lines = markdown.split('\n');
+	const content: AdfBlockNode[] = [];
+	let i = 0;
+
+	while (i < lines.length) {
+		const line = lines[i];
+
+		// Fenced code block
+		if (line.startsWith('```')) {
+			const lang = line.slice(3).trim();
+			const codeLines: string[] = [];
+			i++;
+			while (i < lines.length && !lines[i].startsWith('```')) {
+				codeLines.push(lines[i]);
+				i++;
+			}
+			content.push({
+				type: 'codeBlock',
+				attrs: { language: lang },
+				content: [{ type: 'text', text: codeLines.join('\n') }],
+			});
+			i++;
+			continue;
+		}
+
+		// Heading
+		const headingMatch = line.match(/^(#{1,6})\s+(.*)/);
+		if (headingMatch) {
+			content.push({
+				type: 'heading',
+				attrs: { level: headingMatch[1].length },
+				content: parseInline(headingMatch[2]),
+			});
+			i++;
+			continue;
+		}
+
+		// Horizontal rule
+		if (line.match(/^(-{3,}|\*{3,}|_{3,})$/)) {
+			content.push({ type: 'rule' });
+			i++;
+			continue;
+		}
+
+		// Bullet list
+		if (line.match(/^[-*+]\s+/)) {
+			const items: AdfListItemNode[] = [];
+			while (i < lines.length && lines[i].match(/^[-*+]\s+/)) {
+				items.push({
+					type: 'listItem',
+					content: [{ type: 'paragraph', content: parseInline(lines[i].replace(/^[-*+]\s+/, '')) }],
+				});
+				i++;
+			}
+			content.push({ type: 'bulletList', content: items });
+			continue;
+		}
+
+		// Ordered list
+		if (line.match(/^\d+\.\s+/)) {
+			const items: AdfListItemNode[] = [];
+			while (i < lines.length && lines[i].match(/^\d+\.\s+/)) {
+				items.push({
+					type: 'listItem',
+					content: [{ type: 'paragraph', content: parseInline(lines[i].replace(/^\d+\.\s+/, '')) }],
+				});
+				i++;
+			}
+			content.push({ type: 'orderedList', content: items });
+			continue;
+		}
+
+		// Empty line
+		if (line.trim() === '') {
+			i++;
+			continue;
+		}
+
+		// Paragraph — collect until empty line or block-level element
+		const paraLines: string[] = [];
+		while (
+			i < lines.length &&
+			lines[i].trim() !== '' &&
+			!lines[i].match(/^#{1,6}\s/) &&
+			!lines[i].match(/^[-*+]\s/) &&
+			!lines[i].match(/^\d+\.\s/) &&
+			!lines[i].startsWith('```') &&
+			!lines[i].match(/^(-{3,}|\*{3,}|_{3,})$/)
+		) {
+			paraLines.push(lines[i]);
+			i++;
+		}
+
+		if (paraLines.length > 0) {
+			content.push({
+				type: 'paragraph',
+				content: parseInline(paraLines.join('\n')),
+			});
+		}
+	}
+
+	return content.length > 0 ? { version: 1, type: 'doc', content } : null;
+}

--- a/src/tools/markdownToAdf.ts
+++ b/src/tools/markdownToAdf.ts
@@ -197,3 +197,59 @@ export function markdownToAdf(markdown: string): AdfDoc | null {
 
 	return content.length > 0 ? { version: 1, type: 'doc', content } : null;
 }
+
+function adfInlineToMarkdown(nodes: any[]): string {
+	if (!nodes) return '';
+	return nodes.map(node => {
+		if (node.type === 'hardBreak') return '\n';
+		if (node.type !== 'text') return '';
+		const text = node.text || '';
+		const marks: string[] = (node.marks || []).map((m: any) => m.type);
+		let result = text;
+		if (marks.includes('code')) return `\`${result}\``;
+		if (marks.includes('strong')) result = `**${result}**`;
+		if (marks.includes('em')) result = `*${result}*`;
+		return result;
+	}).join('');
+}
+
+function adfBlockToMarkdown(node: any): string {
+	if (!node) return '';
+
+	switch (node.type) {
+		case 'heading': {
+			const level = node.attrs?.level || 1;
+			const text = adfInlineToMarkdown(node.content || []);
+			return `${'#'.repeat(level)} ${text}`;
+		}
+		case 'paragraph': {
+			const text = adfInlineToMarkdown(node.content || []);
+			return text;
+		}
+		case 'codeBlock': {
+			const lang = node.attrs?.language || '';
+			const code = (node.content || []).map((n: any) => n.text || '').join('');
+			return `\`\`\`${lang}\n${code}\n\`\`\``;
+		}
+		case 'bulletList': {
+			return (node.content || []).map((item: any) =>
+				`- ${(item.content || []).map((block: any) => adfBlockToMarkdown(block)).join('\n')}`
+			).join('\n');
+		}
+		case 'orderedList': {
+			return (node.content || []).map((item: any, i: number) =>
+				`${i + 1}. ${(item.content || []).map((block: any) => adfBlockToMarkdown(block)).join('\n')}`
+			).join('\n');
+		}
+		case 'rule':
+			return '---';
+		default:
+			return (node.content || []).map((n: any) => adfBlockToMarkdown(n)).join('\n');
+	}
+}
+
+export function adfToMarkdown(adf: any): string {
+	if (!adf || typeof adf !== 'object') return '';
+	const blocks: string[] = (adf.content || []).map((node: any) => adfBlockToMarkdown(node));
+	return blocks.filter(b => b !== '').join('\n\n');
+}

--- a/src/tools/markdownToAdf.ts
+++ b/src/tools/markdownToAdf.ts
@@ -202,13 +202,19 @@ function adfInlineToMarkdown(nodes: any[]): string {
 	if (!nodes) return '';
 	return nodes.map(node => {
 		if (node.type === 'hardBreak') return '\n';
+		if (node.type === 'mention') return node.attrs?.text || node.attrs?.displayName || '';
+		if (node.type === 'emoji') return node.attrs?.text || node.attrs?.shortName || '';
+		if (node.type === 'inlineCard') return node.attrs?.url || '';
 		if (node.type !== 'text') return '';
 		const text = node.text || '';
 		const marks: string[] = (node.marks || []).map((m: any) => m.type);
+		const linkMark = (node.marks || []).find((m: any) => m.type === 'link');
 		let result = text;
 		if (marks.includes('code')) return `\`${result}\``;
+		if (marks.includes('strike')) result = `~~${result}~~`;
 		if (marks.includes('strong')) result = `**${result}**`;
 		if (marks.includes('em')) result = `*${result}*`;
+		if (linkMark) result = `[${result}](${linkMark.attrs?.href || ''})`;
 		return result;
 	}).join('');
 }
@@ -243,6 +249,27 @@ function adfBlockToMarkdown(node: any): string {
 		}
 		case 'rule':
 			return '---';
+		case 'blockquote': {
+			const inner = (node.content || []).map((n: any) => adfBlockToMarkdown(n)).join('\n');
+			return inner.split('\n').map((line: string) => `> ${line}`).join('\n');
+		}
+		case 'table': {
+			const rows: any[] = node.content || [];
+			const mdRows = rows.map((row: any) => {
+				const cells = (row.content || []).map((cell: any) =>
+					(cell.content || []).map((n: any) => adfBlockToMarkdown(n)).join(' ').replace(/\|/g, '\\|')
+				);
+				return `| ${cells.join(' | ')} |`;
+			});
+			if (mdRows.length === 0) return '';
+			const sep = `| ${rows[0].content.map(() => '---').join(' | ')} |`;
+			return [mdRows[0], sep, ...mdRows.slice(1)].join('\n');
+		}
+		case 'panel':
+		case 'expand':
+		case 'layoutSection':
+		case 'layoutColumn':
+			return (node.content || []).map((n: any) => adfBlockToMarkdown(n)).join('\n\n');
 		default:
 			return (node.content || []).map((n: any) => adfBlockToMarkdown(n)).join('\n');
 	}


### PR DESCRIPTION
## Summary

- Adds a new **"Add comment to Jira"** command to the command palette
- Opens a modal pre-populated with any text currently selected in the editor — select notes from a non-synced section (e.g. `# Log`) and post them as a comment in one step
- Supports API v2 (plain text body) and v3 (ADF via `markdownToAdf`)
- Ctrl+Enter submits the modal

## Changes

| File | Change |
|---|---|
| `src/api/issues.ts` | Add `addComment()` — POST `/issue/{key}/comment` |
| `src/modals/IssueCommentModal.ts` | New modal with full-width textarea, placeholder hint, Ctrl+Enter |
| `src/modals/index.ts` | Export `IssueCommentModal` |
| `src/commands/addComment.ts` | New command using `editorCheckCallback` to access editor selection |
| `src/commands/index.ts` | Export `registerAddCommentCommand` |
| `src/main.ts` | Register the command |
| `src/localization/source/en\|ru/commands/add_comment.yaml` | New locale strings |
| `src/localization/source/en\|ru/modals/comment.yaml` | New locale strings |

## Notes

- Requires `feature/markdown-to-adf` (uses `markdownToAdf` for API v3 comment bodies)
- Comment field mapping remains read-only (`toJira: null`) — this feature uses a dedicated API call rather than the field mapping system

## Test plan

- [ ] Open a note with a `key` frontmatter field
- [ ] Run "Add comment to Jira" with no selection — modal opens with empty textarea and placeholder hint
- [ ] Run with text selected — modal pre-populates with selected text
- [ ] Submit with button and with Ctrl+Enter
- [ ] Verify comment appears in Jira (API v2 and v3)