### PR TITLE
fix: update issue status no longer clears description and comments

### DIFF
--- a/src/file_operations/createUpdateIssue.ts
+++ b/src/file_operations/createUpdateIssue.ts
@@ -5,6 +5,7 @@ import { prepareJiraFieldsFromFile } from './commonPrepareData';
 import { localToJiraFields, updateJiraToLocal } from '../tools/mapObsidianJiraFields';
 import { JiraIssue, JiraTransitionType } from '../interfaces';
 import { obsidianJiraFieldMappings } from '../default/obsidianJiraFieldsMapping';
+import { updateJiraSyncContent } from '../tools/sectionTools';
 
 export async function updateIssueFromFile(plugin: JiraPlugin, file: TFile): Promise<string> {
 	let fields = await prepareJiraFieldsFromFile(plugin, file);
@@ -72,8 +73,24 @@ export async function updateStatusFromFile(
 	}
 
 	await updateJiraStatus(plugin, fields.key, transition.id);
-	await updateJiraToLocal(plugin, file, {
-		fields: { status: { name: transition.status } },
-	} as JiraIssue);
+
+	// Only update the status field. Calling updateJiraToLocal with a partial issue
+	// causes all fromJira mappings to run with undefined inputs, producing empty strings
+	// that overwrite description and comments.
+	const allMappings = {...obsidianJiraFieldMappings, ...plugin.settings.fieldMapping.fieldMappings};
+	const statusMapping = allMappings['status'];
+	const minimalIssue = {fields: {status: {name: transition.status}}} as JiraIssue;
+	const localStatusValue = statusMapping
+		? statusMapping.fromJira(minimalIssue, {})
+		: transition.status;
+
+	if (localStatusValue !== null && localStatusValue !== undefined) {
+		await plugin.app.fileManager.processFrontmatter(file, (frontmatter) => {
+			frontmatter['status'] = localStatusValue;
+		});
+		await plugin.app.vault.process(file, (fileContent) => {
+			return updateJiraSyncContent(fileContent, {status: String(localStatusValue)});
+		});
+	}
 	return fields.key;
 }

--- a/src/file_operations/createUpdateIssue.ts
+++ b/src/file_operations/createUpdateIssue.ts
@@ -79,13 +79,13 @@ export async function updateStatusFromFile(
 	// that overwrite description and comments.
 	const allMappings = {...obsidianJiraFieldMappings, ...plugin.settings.fieldMapping.fieldMappings};
 	const statusMapping = allMappings['status'];
-	const minimalIssue = {fields: {status: {name: transition.status}}} as JiraIssue;
+	const minimalIssue = {fields: {status: {name: transition.status}}} as any as JiraIssue;
 	const localStatusValue = statusMapping
-		? statusMapping.fromJira(minimalIssue, {})
+		? statusMapping.fromJira(minimalIssue, plugin.getCurrentConnection()?.apiVersion)
 		: transition.status;
 
 	if (localStatusValue !== null && localStatusValue !== undefined) {
-		await plugin.app.fileManager.processFrontmatter(file, (frontmatter) => {
+		await plugin.app.fileManager.processFrontMatter(file, (frontmatter: any) => {
 			frontmatter['status'] = localStatusValue;
 		});
 		await plugin.app.vault.process(file, (fileContent) => {

--- a/src/tools/markdownHtml.ts
+++ b/src/tools/markdownHtml.ts
@@ -3,9 +3,10 @@
  * @param str The Jira markup string
  * @returns The Markdown string
  */
-export function jiraToMarkdown(str: any): string {
+export function jiraToMarkdown(str: any): string | null {
 	try {
-		if (str === null || str === undefined) return '';
+		if (str === undefined) return null;
+		if (str === null) return '';
 
 		// Initial normalization to string
 		let content: string = '';

--- a/src/tools/markdownToAdf.ts
+++ b/src/tools/markdownToAdf.ts
@@ -426,7 +426,8 @@ function adfBlockToMarkdown(node: any): string {
 	}
 }
 
-export function adfToMarkdown(adf: any): string {
+export function adfToMarkdown(adf: any): string | null {
+	if (adf === undefined) return null;
 	if (!adf || typeof adf !== 'object') return '';
 	const blocks: string[] = (adf.content || []).map((node: any) => adfBlockToMarkdown(node));
 	return blocks.filter((b) => b !== '').join('\n\n');

--- a/src/tools/markdownToAdf.ts
+++ b/src/tools/markdownToAdf.ts
@@ -47,9 +47,15 @@ interface AdfOrderedListNode {
 	content: AdfListItemNode[];
 }
 
+interface AdfTaskItemNode {
+	type: 'taskItem';
+	attrs: { localId: string; state: 'TODO' | 'DONE' };
+	content: AdfInlineContent[];
+}
+
 interface AdfTaskListNode {
 	type: 'taskList';
-	content: AdfListItemNode[];
+	content: AdfTaskItemNode[];
 	attrs?: { localId: string };
 }
 


### PR DESCRIPTION
## Summary

`updateStatusFromFile()` was calling `updateJiraToLocal()` with a minimal fake issue object `{fields: {status: {name: transition.status}}}`. Every `fromJira` mapping ran against this object, receiving `undefined` for all fields except status. For example `adfToMarkdown(undefined)` returns `''`, which passed the `!== null` guard and overwrote existing content with empty strings.

## Fix

Replaced the `updateJiraToLocal` call with a targeted status-only update: evaluates only the `status` field mapping against the minimal issue, then writes the result directly to frontmatter via `processFrontMatter` and to any sync markers via `updateJiraSyncContent`. No other fields are touched.

## Test plan

- [ ] Update issue status — description and comments are preserved in the note
- [ ] Status field updates correctly in frontmatter